### PR TITLE
crosscompile for Scala 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         scala:
           - 2.13.16
+          - 3.3.6
 
     steps:
       - uses: actions/checkout@v4

--- a/actor-tests/src/test/scala/com/evolution/pekkoeffect/ActorOfTest.scala
+++ b/actor-tests/src/test/scala/com/evolution/pekkoeffect/ActorOfTest.scala
@@ -1,7 +1,5 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.*
-import org.apache.pekko.testkit.TestActors
 import cats.effect.*
 import cats.effect.syntax.all.*
 import cats.effect.unsafe.implicits.global
@@ -10,6 +8,8 @@ import com.evolution.pekkoeffect.IOSuite.*
 import com.evolution.pekkoeffect.testkit.Probe
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.{FromFuture, ToFuture}
+import org.apache.pekko.actor.*
+import org.apache.pekko.testkit.TestActors
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -167,19 +167,19 @@ class ActorOfTest extends AsyncFunSuite with ActorSuite with Matchers {
     } yield result
   }
 
+  private case class GetAndInc[F[_]](delay: F[Unit])
+
   private def receive[F[_]: Async: ToFuture: FromFuture](
     actorSystem: ActorSystem,
     shift: F[Unit],
   ): F[Unit] = {
-
-    case class GetAndInc(delay: F[Unit])
 
     def receiveOf = ReceiveOf.const {
       val receive = for {
         state <- Ref[F].of(0)
       } yield Receive[Call[F, Any, Any]] { call =>
         call.msg match {
-          case a: GetAndInc =>
+          case a: GetAndInc[F] @unchecked =>
             for {
               _ <- shift
               _ <- a.delay

--- a/actor-tests/src/test/scala/com/evolution/pekkoeffect/ActorSuite.scala
+++ b/actor-tests/src/test/scala/com/evolution/pekkoeffect/ActorSuite.scala
@@ -1,12 +1,12 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.ActorSystem
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import com.evolution.pekkoeffect.testkit.TestActorSystem
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.typesafe.config.Config
+import org.apache.pekko.actor.ActorSystem
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
 trait ActorSuite extends BeforeAndAfterAll { self: Suite =>

--- a/actor-tests/src/test/scala/com/evolution/pekkoeffect/AskFromTest.scala
+++ b/actor-tests/src/test/scala/com/evolution/pekkoeffect/AskFromTest.scala
@@ -1,12 +1,12 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.ActorRef
 import cats.effect.unsafe.implicits.global
 import cats.effect.{Async, IO, Resource, Sync}
 import cats.syntax.all.*
 import com.evolution.pekkoeffect.IOSuite.*
 import com.evolution.pekkoeffect.testkit.Probe
 import com.evolutiongaming.catshelper.{FromFuture, ToFuture}
+import org.apache.pekko.actor.ActorRef
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 

--- a/actor-tests/src/test/scala/com/evolution/pekkoeffect/AskTest.scala
+++ b/actor-tests/src/test/scala/com/evolution/pekkoeffect/AskTest.scala
@@ -1,12 +1,12 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.testkit.TestActors
 import cats.arrow.FunctionK
 import cats.effect.{Async, IO, Sync}
 import cats.syntax.all.*
 import com.evolution.pekkoeffect.IOSuite.*
 import com.evolutiongaming.catshelper.FromFuture
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.testkit.TestActors
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 

--- a/actor-tests/src/test/scala/com/evolution/pekkoeffect/CounterSpec.scala
+++ b/actor-tests/src/test/scala/com/evolution/pekkoeffect/CounterSpec.scala
@@ -1,12 +1,12 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.ActorSystem
 import cats.effect.*
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import com.evolution.pekkoeffect.IOSuite.*
 import com.evolution.pekkoeffect.testkit.Probe
 import com.evolutiongaming.catshelper.{FromFuture, ToFuture}
+import org.apache.pekko.actor.ActorSystem
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -127,5 +127,5 @@ object CounterSpec {
     case object Stop extends Msg
   }
 
-  final case object PostStop
+  case object PostStop
 }

--- a/actor-tests/src/test/scala/com/evolution/pekkoeffect/ReplyStatusTest.scala
+++ b/actor-tests/src/test/scala/com/evolution/pekkoeffect/ReplyStatusTest.scala
@@ -1,7 +1,5 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.{ActorSystem, Status}
-import org.apache.pekko.testkit.TestActors
 import cats.arrow.FunctionK
 import cats.effect.unsafe.implicits.global
 import cats.effect.{Async, IO, Sync}
@@ -9,6 +7,8 @@ import cats.syntax.all.*
 import com.evolution.pekkoeffect.IOSuite.*
 import com.evolution.pekkoeffect.testkit.Probe
 import com.evolutiongaming.catshelper.{FromFuture, ToFuture}
+import org.apache.pekko.actor.{ActorSystem, Status}
+import org.apache.pekko.testkit.TestActors
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 

--- a/actor-tests/src/test/scala/com/evolution/pekkoeffect/ReplyTest.scala
+++ b/actor-tests/src/test/scala/com/evolution/pekkoeffect/ReplyTest.scala
@@ -1,7 +1,5 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.testkit.TestActors
 import cats.arrow.FunctionK
 import cats.effect.unsafe.implicits.global
 import cats.effect.{Async, IO, Sync}
@@ -9,6 +7,8 @@ import cats.syntax.all.*
 import com.evolution.pekkoeffect.IOSuite.*
 import com.evolution.pekkoeffect.testkit.Probe
 import com.evolutiongaming.catshelper.{FromFuture, ToFuture}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.testkit.TestActors
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 

--- a/actor-tests/src/test/scala/com/evolution/pekkoeffect/TellSpec.scala
+++ b/actor-tests/src/test/scala/com/evolution/pekkoeffect/TellSpec.scala
@@ -1,7 +1,5 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.testkit.TestActors
 import cats.arrow.FunctionK
 import cats.effect.unsafe.implicits.global
 import cats.effect.{Async, IO, Sync}
@@ -9,6 +7,8 @@ import cats.syntax.all.*
 import com.evolution.pekkoeffect.IOSuite.*
 import com.evolution.pekkoeffect.testkit.Probe
 import com.evolutiongaming.catshelper.{FromFuture, ToFuture}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.testkit.TestActors
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 

--- a/actor-tests/src/test/scala/com/evolution/pekkoeffect/util/TerminatedTest.scala
+++ b/actor-tests/src/test/scala/com/evolution/pekkoeffect/util/TerminatedTest.scala
@@ -1,6 +1,5 @@
 package com.evolution.pekkoeffect.util
 
-import org.apache.pekko.actor.ActorSystem
 import cats.effect.implicits.*
 import cats.effect.unsafe.implicits.global
 import cats.effect.{Async, IO, Resource}
@@ -8,6 +7,7 @@ import cats.syntax.all.*
 import com.evolution.pekkoeffect.*
 import com.evolution.pekkoeffect.IOSuite.*
 import com.evolutiongaming.catshelper.{FromFuture, ToFuture}
+import org.apache.pekko.actor.ActorSystem
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 

--- a/actor/src/main/scala/com/evolution/pekkoeffect/Act.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/Act.scala
@@ -1,10 +1,10 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.{Actor, ActorRef}
 import cats.effect.{Async, Sync}
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.{Serial, ToTry}
+import org.apache.pekko.actor.{Actor, ActorRef}
 
 /** Act executes function in `receive` thread of an actor
   */
@@ -63,9 +63,9 @@ private[pekkoeffect] object Act {
       apply(tell)
     }
 
-    def apply[F[_]: Async](tell: Any => Unit): Adapter[F] = {
+    private case class Msg(f: () => Unit)
 
-      case class Msg(f: () => Unit)
+    def apply[F[_]: Async](tell: Any => Unit): Adapter[F] =
 
       new Adapter[F] { self =>
         private val selfOpt = self.some
@@ -128,6 +128,5 @@ private[pekkoeffect] object Act {
           finally threadLocal.set(None)
         }
       }
-    }
   }
 }

--- a/actor/src/main/scala/com/evolution/pekkoeffect/ActorCtx.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/ActorCtx.scala
@@ -1,9 +1,9 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.{ActorContext, ActorRef, ActorRefFactory}
 import cats.effect.Sync
 import cats.syntax.all.*
 import cats.{Monad, ~>}
+import org.apache.pekko.actor.{ActorContext, ActorRef, ActorRefFactory}
 
 import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration.Duration

--- a/actor/src/main/scala/com/evolution/pekkoeffect/ActorEffect.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/ActorEffect.scala
@@ -1,9 +1,9 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.{ActorPath, ActorRef, Props}
 import cats.effect.{Async, Resource, Sync}
 import cats.{Applicative, FlatMap, ~>}
 import com.evolutiongaming.catshelper.{FromFuture, ToFuture}
+import org.apache.pekko.actor.{ActorPath, ActorRef, Props}
 
 /** Typesafe api for ActorRef
   *

--- a/actor/src/main/scala/com/evolution/pekkoeffect/ActorOf.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/ActorOf.scala
@@ -1,6 +1,5 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.{Actor, ActorRef, ReceiveTimeout}
 import cats.effect.*
 import cats.effect.implicits.effectResourceOps
 import cats.syntax.all.*
@@ -8,6 +7,7 @@ import com.evolution.pekkoeffect.ActorVar.Directive
 import com.evolution.pekkoeffect.Fail.implicits.*
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.ToFuture
+import org.apache.pekko.actor.{Actor, ActorRef, ReceiveTimeout}
 
 /** Creates instance of [[org.apache.pekko.actor.Actor]] out of [[ReceiveOf]]
   */

--- a/actor/src/main/scala/com/evolution/pekkoeffect/ActorRefOf.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/ActorRefOf.scala
@@ -1,9 +1,9 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.{ActorRef, ActorRefFactory, Props}
 import cats.effect.kernel.MonadCancel
 import cats.effect.{Resource, Sync}
 import cats.~>
+import org.apache.pekko.actor.{ActorRef, ActorRefFactory, Props}
 
 /** Resource-full api for ActorRefFactory
   *

--- a/actor/src/main/scala/com/evolution/pekkoeffect/ActorVar.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/ActorVar.scala
@@ -1,11 +1,11 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.ActorContext
 import cats.effect.*
 import cats.syntax.all.*
 import com.evolution.pekkoeffect.util.Serially
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.ToFuture
+import org.apache.pekko.actor.ActorContext
 
 import scala.util.control.NoStackTrace
 
@@ -117,9 +117,9 @@ private[pekkoeffect] object ActorVar {
 
     final case class Update[A](value: A) extends Directive[A]
 
-    final case object Ignore extends Directive[Nothing]
+    case object Ignore extends Directive[Nothing]
 
-    final case object Stop extends Directive[Nothing]
+    case object Stop extends Directive[Nothing]
 
     implicit class DirectiveOps[A](val self: Directive[A]) extends AnyVal {
 

--- a/actor/src/main/scala/com/evolution/pekkoeffect/Ask.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/Ask.scala
@@ -1,11 +1,11 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.{ActorRef, ActorSelection}
-import org.apache.pekko.util.Timeout
 import cats.effect.Sync
 import cats.syntax.all.*
 import cats.{Applicative, Contravariant, FlatMap, Functor, ~>}
 import com.evolutiongaming.catshelper.FromFuture
+import org.apache.pekko.actor.{ActorRef, ActorSelection}
+import org.apache.pekko.util.Timeout
 
 import scala.concurrent.duration.FiniteDuration
 

--- a/actor/src/main/scala/com/evolution/pekkoeffect/AskFrom.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/AskFrom.scala
@@ -1,10 +1,10 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.{Actor, ActorRef, Props}
-import org.apache.pekko.util.Timeout
 import cats.effect.{Resource, Sync}
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.FromFuture
+import org.apache.pekko.actor.{Actor, ActorRef, Props}
+import org.apache.pekko.util.Timeout
 
 import scala.concurrent.duration.FiniteDuration
 import scala.reflect.ClassTag
@@ -24,8 +24,6 @@ object AskFrom {
     timeout: FiniteDuration,
   ): Resource[F, AskFrom[F]] = {
 
-    final case class Msg(to: ActorRef, f: ActorRef => Any)
-
     def actor() = new Actor {
       def receive = {
         case Msg(to, f) => to.tell(f(sender()), sender())
@@ -44,4 +42,6 @@ object AskFrom {
       }
     }
   }
+
+  final private case class Msg(to: ActorRef, f: ActorRef => Any)
 }

--- a/actor/src/main/scala/com/evolution/pekkoeffect/Envelope.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/Envelope.scala
@@ -1,10 +1,10 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.ActorRef
 import cats.Functor
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.MonadThrowable
+import org.apache.pekko.actor.ActorRef
 
 import scala.reflect.ClassTag
 

--- a/actor/src/main/scala/com/evolution/pekkoeffect/EventStream.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/EventStream.scala
@@ -1,9 +1,9 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
 import cats.effect.{Async, Resource, Sync}
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.ToFuture
+import org.apache.pekko.actor.{ActorRef, ActorRefFactory, ActorSystem, Props}
 
 import scala.reflect.ClassTag
 

--- a/actor/src/main/scala/com/evolution/pekkoeffect/Fail.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/Fail.scala
@@ -1,8 +1,8 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.ActorRef
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.{ApplicativeThrowable, MonadThrowable}
+import org.apache.pekko.actor.ActorRef
 
 trait Fail[F[_]] {
 

--- a/actor/src/main/scala/com/evolution/pekkoeffect/Receive.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/Receive.scala
@@ -1,9 +1,9 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.ActorRef
 import cats.effect.Sync
 import cats.syntax.all.*
 import cats.{Contravariant, FlatMap, Functor, Monad, ~>}
+import org.apache.pekko.actor.ActorRef
 
 /** Api for Actor.receive
   *

--- a/actor/src/main/scala/com/evolution/pekkoeffect/Reply.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/Reply.scala
@@ -1,10 +1,10 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.ActorRef
-import org.apache.pekko.actor.Status.Status
 import cats.effect.Sync
 import cats.syntax.all.*
 import cats.{Applicative, Contravariant, FlatMap, ~>}
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.actor.Status.Status
 
 /** Typesafe api for replying part of "ask pattern"
   *

--- a/actor/src/main/scala/com/evolution/pekkoeffect/ReplyStatus.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/ReplyStatus.scala
@@ -1,10 +1,10 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.Status.Status
-import org.apache.pekko.actor.{ActorRef, Status}
 import cats.effect.Sync
 import cats.syntax.all.*
 import cats.{Contravariant, FlatMap, ~>}
+import org.apache.pekko.actor.Status.Status
+import org.apache.pekko.actor.{ActorRef, Status}
 
 /** Typesafe api for replying part of "ask pattern" in conjunction with `Status`
   *

--- a/actor/src/main/scala/com/evolution/pekkoeffect/Tell.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/Tell.scala
@@ -1,9 +1,9 @@
 package com.evolution.pekkoeffect
 
-import org.apache.pekko.actor.ActorRef
 import cats.effect.Sync
 import cats.syntax.all.*
 import cats.{Applicative, Contravariant, FlatMap, ~>}
+import org.apache.pekko.actor.ActorRef
 
 /** Typesafe api for ActorRef.tell
   *

--- a/actor/src/main/scala/com/evolution/pekkoeffect/util/Serially.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/util/Serially.scala
@@ -25,7 +25,7 @@ private[pekkoeffect] object Serially {
     object S {
       final case class Idle(value: A)     extends S // no tasks are running, `value` is result of last task
       final case class Active(task: Task) extends S // task is running and next `task` is waiting its order
-      final case object Active            extends S // task is running, nothing else scheduled
+      case object Active                  extends S // task is running, nothing else scheduled
     }
 
     val ref = new AtomicReference[S](S.Idle(value))

--- a/actor/src/main/scala/com/evolution/pekkoeffect/util/Terminated.scala
+++ b/actor/src/main/scala/com/evolution/pekkoeffect/util/Terminated.scala
@@ -1,12 +1,12 @@
 package com.evolution.pekkoeffect.util
 
-import org.apache.pekko.actor.{Actor, ActorRef, Props}
 import cats.effect.Concurrent
 import cats.effect.kernel.Deferred
 import cats.syntax.all.*
 import com.evolution.pekkoeffect.{ActorEffect, ActorRefOf}
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.ToFuture
+import org.apache.pekko.actor.{Actor, ActorRef, Props}
 
 trait Terminated[F[_]] {
 

--- a/actor/src/test/scala/com/evolution/pekkoeffect/ActorVarTest.scala
+++ b/actor/src/test/scala/com/evolution/pekkoeffect/ActorVarTest.scala
@@ -23,8 +23,8 @@ class ActorVarTest extends AsyncFunSuite with Matchers {
     sealed trait Action
 
     object Action {
-      final case object Allocated                                  extends Action
-      final case object Released                                   extends Action
+      case object Allocated                                        extends Action
+      case object Released                                         extends Action
       final case class Updated(before: Int, after: Directive[Int]) extends Action
       final case class Released(state: Int)                        extends Action
     }

--- a/actor/src/test/scala/com/evolution/pekkoeffect/ExtractTest.scala
+++ b/actor/src/test/scala/com/evolution/pekkoeffect/ExtractTest.scala
@@ -21,9 +21,9 @@ class ExtractTest extends AnyFunSuite with Matchers {
   ).foreach {
     case (a, expected) =>
       test(s"either $a") {
-        implicit val extractStr  = Extract.fromClassTag[Try, String]
-        implicit val extractLong = Extract.fromClassTag[Try, Long]
-        val extractToJsonAble    = Extract.either[Try, String, Long]
+        implicit val extractStr: Extract[Try, String] = Extract.fromClassTag[Try, String]
+        implicit val extractLong: Extract[Try, Long]  = Extract.fromClassTag[Try, Long]
+        val extractToJsonAble                         = Extract.either[Try, String, Long]
         extractToJsonAble(a) shouldEqual expected.toOptionT[Try]
       }
   }

--- a/cluster-sharding/src/main/scala/com/evolution/pekkoeffect/cluster/sharding/ClusterSharding.scala
+++ b/cluster-sharding/src/main/scala/com/evolution/pekkoeffect/cluster/sharding/ClusterSharding.scala
@@ -1,9 +1,5 @@
 package com.evolution.pekkoeffect.cluster.sharding
 
-import org.apache.pekko.actor.{ActorRef, ActorSystem, Props}
-import org.apache.pekko.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
-import org.apache.pekko.cluster.sharding.ShardRegion.*
-import org.apache.pekko.cluster.sharding.{ClusterShardingSettings, ShardRegion}
 import cats.effect.implicits.*
 import cats.effect.{Async, Resource, Sync}
 import cats.syntax.all.*
@@ -13,6 +9,10 @@ import com.evolution.pekkoeffect.util.Terminated
 import com.evolution.pekkoeffect.{ActorRefOf, Ask}
 import com.evolutiongaming.catshelper.*
 import com.evolutiongaming.catshelper.CatsHelper.*
+import org.apache.pekko.actor.{ActorRef, ActorSystem, Props}
+import org.apache.pekko.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
+import org.apache.pekko.cluster.sharding.ShardRegion.*
+import org.apache.pekko.cluster.sharding.{ClusterShardingSettings, ShardRegion}
 
 import scala.concurrent.duration.*
 

--- a/cluster-sharding/src/main/scala/com/evolution/pekkoeffect/cluster/sharding/ClusterShardingLocal.scala
+++ b/cluster-sharding/src/main/scala/com/evolution/pekkoeffect/cluster/sharding/ClusterShardingLocal.scala
@@ -1,9 +1,5 @@
 package com.evolution.pekkoeffect.cluster.sharding
 
-import org.apache.pekko.actor.*
-import org.apache.pekko.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
-import org.apache.pekko.cluster.sharding.ShardRegion.{ShardId, ShardState}
-import org.apache.pekko.cluster.sharding.{ClusterShardingSettings, ShardRegion}
 import cats.effect.syntax.resource.*
 import cats.effect.{Async, Ref, Resource}
 import cats.syntax.all.*
@@ -13,6 +9,10 @@ import com.evolution.pekkoeffect.util.Terminated
 import com.evolution.pekkoeffect.{ActorRefOf, Ask}
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.{FromFuture, ToFuture, ToTry}
+import org.apache.pekko.actor.*
+import org.apache.pekko.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
+import org.apache.pekko.cluster.sharding.ShardRegion.{ShardId, ShardState}
+import org.apache.pekko.cluster.sharding.{ClusterShardingSettings, ShardRegion}
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -42,16 +42,6 @@ object ClusterShardingLocal {
   ): Resource[F, ClusterShardingLocal[F]] = {
 
     def actorNameOf(a: String) = URLEncoder.encode(a, StandardCharsets.UTF_8.name())
-
-    case class ShardingMsg(f: ActorContext => Unit)
-
-    sealed trait RegionMsg
-
-    object RegionMsg {
-
-      final case object Rebalance extends RegionMsg
-      final case object State     extends RegionMsg
-    }
 
     def shardingActor(): Actor = new Actor {
 
@@ -274,4 +264,15 @@ object ClusterShardingLocal {
       }
     }
   }
+
+  private case class ShardingMsg(f: ActorContext => Unit)
+
+  sealed private trait RegionMsg
+
+  private object RegionMsg {
+
+    case object Rebalance extends RegionMsg
+    case object State     extends RegionMsg
+  }
+
 }

--- a/cluster-sharding/src/test/scala/com/evolution/pekkoeffect/cluster/sharding/ClusterShardingLocalTest.scala
+++ b/cluster-sharding/src/test/scala/com/evolution/pekkoeffect/cluster/sharding/ClusterShardingLocalTest.scala
@@ -1,15 +1,15 @@
 package com.evolution.pekkoeffect.cluster.sharding
 
-import org.apache.pekko.actor.{Actor, ActorRef, Props}
-import org.apache.pekko.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
-import org.apache.pekko.cluster.sharding.ShardRegion.{ShardId, ShardState}
-import org.apache.pekko.cluster.sharding.{ClusterShardingSettings, ShardRegion}
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.evolution.pekkoeffect.IOSuite.*
 import com.evolution.pekkoeffect.persistence.TypeName
 import com.evolution.pekkoeffect.testkit.Probe
 import com.evolution.pekkoeffect.{ActorEffect, ActorRefOf, ActorSuite}
+import org.apache.pekko.actor.{Actor, ActorRef, Props}
+import org.apache.pekko.cluster.sharding.ShardCoordinator.ShardAllocationStrategy
+import org.apache.pekko.cluster.sharding.ShardRegion.{ShardId, ShardState}
+import org.apache.pekko.cluster.sharding.{ClusterShardingSettings, ShardRegion}
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -19,11 +19,11 @@ import scala.concurrent.duration.*
 
 class ClusterShardingLocalTest extends AsyncFunSuite with ActorSuite with Matchers {
 
+  private case class ShardedMsg(id: String, msg: Int)
+
   test("clusterShardingLocal") {
 
     case object HandOffStopMsg
-
-    case class ShardedMsg(id: String, msg: Int)
 
     val actorRefOf = ActorRefOf.fromActorRefFactory[IO](actorSystem)
 

--- a/cluster-sharding/src/test/scala/com/evolution/pekkoeffect/cluster/sharding/ClusterShardingTest.scala
+++ b/cluster-sharding/src/test/scala/com/evolution/pekkoeffect/cluster/sharding/ClusterShardingTest.scala
@@ -1,9 +1,5 @@
 package com.evolution.pekkoeffect.cluster.sharding
 
-import org.apache.pekko.actor.{Actor, Props}
-import org.apache.pekko.cluster.sharding.ClusterShardingSettings
-import org.apache.pekko.cluster.sharding.ShardCoordinator.LeastShardAllocationStrategy
-import org.apache.pekko.cluster.sharding.ShardRegion.Msg
 import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, Resource}
 import cats.syntax.all.*
@@ -13,6 +9,10 @@ import com.evolution.pekkoeffect.testkit.Probe
 import com.evolution.pekkoeffect.{ActorRefOf, ActorSuite}
 import com.evolutiongaming.catshelper.LogOf
 import com.typesafe.config.ConfigFactory
+import org.apache.pekko.actor.{Actor, Props}
+import org.apache.pekko.cluster.sharding.ClusterShardingSettings
+import org.apache.pekko.cluster.sharding.ShardCoordinator.LeastShardAllocationStrategy
+import org.apache.pekko.cluster.sharding.ShardRegion.Msg
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 

--- a/eventsourcing/src/main/scala/com/evolution/pekkoeffect/eventsourcing/Engine.scala
+++ b/eventsourcing/src/main/scala/com/evolution/pekkoeffect/eventsourcing/Engine.scala
@@ -1,8 +1,5 @@
 package com.evolution.pekkoeffect.eventsourcing
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.*
-import org.apache.pekko.stream.scaladsl.{Sink, Source}
 import cats.data.NonEmptyList as Nel
 import cats.effect.*
 import cats.effect.implicits.*
@@ -14,6 +11,9 @@ import com.evolution.pekkoeffect.persistence.{Events, SeqNr}
 import com.evolution.pekkoeffect.util.CloseOnError
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.{FromFuture, Runtime, SerParQueue, ToFuture}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.*
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
 
 trait Engine[F[_], S, E] {
   import Engine._

--- a/eventsourcing/src/main/scala/com/evolution/pekkoeffect/eventsourcing/JournalKeeper.scala
+++ b/eventsourcing/src/main/scala/com/evolution/pekkoeffect/eventsourcing/JournalKeeper.scala
@@ -1,6 +1,5 @@
 package com.evolution.pekkoeffect.eventsourcing
 
-import org.apache.pekko.persistence.SnapshotSelectionCriteria
 import cats.Applicative
 import cats.effect.implicits.*
 import cats.effect.{Clock, Concurrent, Ref}
@@ -10,6 +9,7 @@ import com.evolution.pekkoeffect.ActorStoppedError
 import com.evolution.pekkoeffect.persistence.{SeqNr, SnapshotMetadata, Snapshotter}
 import com.evolutiongaming.catshelper.ClockHelper.*
 import com.evolutiongaming.catshelper.Log
+import org.apache.pekko.persistence.SnapshotSelectionCriteria
 import pureconfig.ConfigReader
 import pureconfig.generic.semiauto.deriveReader
 

--- a/eventsourcing/src/main/scala/com/evolution/pekkoeffect/eventsourcing/util/ResourceFromQueue.scala
+++ b/eventsourcing/src/main/scala/com/evolution/pekkoeffect/eventsourcing/util/ResourceFromQueue.scala
@@ -1,9 +1,9 @@
 package com.evolution.pekkoeffect.eventsourcing.util
 
-import org.apache.pekko.stream.scaladsl.SourceQueueWithComplete
 import cats.effect.{Resource, Sync}
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.FromFuture
+import org.apache.pekko.stream.scaladsl.SourceQueueWithComplete
 
 object ResourceFromQueue {
 

--- a/eventsourcing/src/test/scala/com/evolution/pekkoeffect/eventsourcing/JournalKeeperTest.scala
+++ b/eventsourcing/src/test/scala/com/evolution/pekkoeffect/eventsourcing/JournalKeeperTest.scala
@@ -1,6 +1,5 @@
 package com.evolution.pekkoeffect.eventsourcing
 
-import org.apache.pekko.persistence.SnapshotSelectionCriteria
 import cats.Monad
 import cats.effect.*
 import cats.syntax.all.*
@@ -8,6 +7,7 @@ import com.evolution.pekkoeffect.IOSuite.*
 import com.evolution.pekkoeffect.persistence.{SeqNr, SnapshotMetadata, Snapshotter}
 import com.evolutiongaming.catshelper.ClockHelper.*
 import com.evolutiongaming.catshelper.Log
+import org.apache.pekko.persistence.SnapshotSelectionCriteria
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 

--- a/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/Append.scala
+++ b/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/Append.scala
@@ -1,6 +1,5 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.persistence.*
 import cats.effect.kernel.Async
 import cats.effect.{Deferred, Resource, Sync}
 import cats.implicits.*
@@ -9,6 +8,7 @@ import com.evolution.pekkoeffect.util.AtomicRef
 import com.evolution.pekkoeffect.{Act, Fail}
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.{Log, MeasureDuration, MonadThrowable, ToFuture}
+import org.apache.pekko.persistence.*
 
 import scala.collection.immutable.Queue
 

--- a/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/DeleteEventsTo.scala
+++ b/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/DeleteEventsTo.scala
@@ -1,11 +1,11 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.persistence.DeleteEventsToInterop
 import cats.effect.{Resource, Sync}
 import cats.syntax.all.*
 import cats.{Applicative, FlatMap, ~>}
 import com.evolution.pekkoeffect.Fail
 import com.evolutiongaming.catshelper.{FromFuture, Log, MeasureDuration, MonadThrowable}
+import org.apache.pekko.persistence.DeleteEventsToInterop
 
 import scala.concurrent.duration.FiniteDuration
 

--- a/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/EventSourced.scala
+++ b/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/EventSourced.scala
@@ -1,8 +1,8 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.persistence.Recovery
 import cats.syntax.all.*
 import cats.{Functor, Show}
+import org.apache.pekko.persistence.Recovery
 
 /** @param eventSourcedId
   *   \@see [[org.apache.pekko.persistence.PersistentActor.persistenceId]]

--- a/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/EventSourcedActorEffect.scala
+++ b/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/EventSourcedActorEffect.scala
@@ -1,9 +1,9 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.actor.Props
 import cats.effect.{Async, Resource}
 import com.evolution.pekkoeffect.{ActorEffect, ActorRefOf}
 import com.evolutiongaming.catshelper.{FromFuture, LogOf, ToFuture}
+import org.apache.pekko.actor.Props
 
 object EventSourcedActorEffect {
 

--- a/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/EventSourcedActorOf.scala
+++ b/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/EventSourcedActorOf.scala
@@ -1,13 +1,13 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.actor.Actor
-import org.apache.pekko.persistence.SnapshotSelectionCriteria
 import cats.effect.implicits.effectResourceOps
 import cats.effect.{Async, Concurrent, Ref, Resource}
 import cats.syntax.all.*
 import com.evolution.pekkoeffect.*
 import com.evolution.pekkoeffect.persistence.SeqNr
 import com.evolutiongaming.catshelper.{Log, LogOf, ToFuture}
+import org.apache.pekko.actor.Actor
+import org.apache.pekko.persistence.SnapshotSelectionCriteria
 
 import java.time.Instant
 
@@ -69,11 +69,10 @@ object EventSourcedActorOf {
     LogOf
       .log[F, EventSourcedActorOf.type]
       .toResource
-      .flatMap { implicit log0 =>
-        implicit val log =
+      .flatMap { log0 =>
+        implicit val log: Log[F] =
           log0
             .prefixed(actorCtx.self.path.name)
-            .mapK(Resource.liftK[F])
         val receive = for {
           eventSourced    <- eventSourcedOf(actorCtx).toResource
           recoveryStarted <- eventSourced.value
@@ -82,7 +81,7 @@ object EventSourcedActorOf {
           eventStore    <- persistence.eventStore(eventSourced).toResource
 
           snapshot <- snapshotStore.latest.toResource
-          _        <- log.debug(s"using snapshot $snapshot")
+          _        <- log.debug(s"using snapshot $snapshot").toResource
 
           recovering <- recoveryStarted(
             snapshot.map(_.metadata.seqNr).getOrElse(SeqNr.Min),
@@ -97,7 +96,7 @@ object EventSourcedActorOf {
             // used to recover events _following_ the snapshot OR if no snapshot available then [[SeqNr.Min]]
             val fromSeqNr = snapshot.map(_.metadata.seqNr + 1).getOrElse(SeqNr.Min)
             for {
-              _      <- log.debug(s"snapshot seqNr: $snapSeqNr, load events from seqNr: $fromSeqNr").allocated
+              _ <- log.debug(s"snapshot seqNr: $snapSeqNr, load events from seqNr: $fromSeqNr").toResource.allocated
               events <- eventStore.events(fromSeqNr)
               seqNrL <- events.foldWhileM(snapSeqNr) {
                 case (_, EventStore.Event(event, seqNr)) => replay(event, seqNr).as(seqNr.asLeft[Unit])
@@ -114,14 +113,14 @@ object EventSourcedActorOf {
             } yield seqNr
           }.toResource
 
-          _          <- log.debug(s"recovery completed with seqNr $seqNr")
+          _          <- log.debug(s"recovery completed with seqNr $seqNr").toResource
           journaller <- eventStore.asJournaller(actorCtx, seqNr).toResource
           context     = Recovering.RecoveryContext(seqNr, journaller, snapshotStore.asSnapshotter)
           receive    <- recovering.completed(context)
         } yield receive
 
         receive.onError {
-          case err: Throwable => log.error(s"failed to allocate receive", err)
+          case err: Throwable => log.error(s"failed to allocate receive", err).toResource
         }
       }
   }
@@ -136,8 +135,7 @@ object EventSourcedActorOf {
 
   }
 
-  implicit final private[evolution] class SnapshotStoreOps[F[_], A](val store: SnapshotStore[F, A])
-      extends AnyVal {
+  implicit final private[evolution] class SnapshotStoreOps[F[_], A](val store: SnapshotStore[F, A]) extends AnyVal {
 
     def asSnapshotter: Snapshotter[F, A] = new Snapshotter[F, A] {
 
@@ -174,10 +172,11 @@ object EventSourcedActorOf {
                 }
               }
               .flatMap { events =>
-                def handleError(err: Throwable) = {
-                  val from = events.values.head.head.seqNr
-                  val to   = events.values.last.last.seqNr
-                  stopActor(from, to, err)
+                def handleError: PartialFunction[Throwable, F[Unit]] = {
+                  case err: Throwable =>
+                    val from = events.values.head.head.seqNr
+                    val to   = events.values.last.last.seqNr
+                    stopActor(from, to, err)
                 }
                 store
                   .save(events)

--- a/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/EventSourcedPersistence.scala
+++ b/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/EventSourcedPersistence.scala
@@ -1,9 +1,9 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.persistence.{EventStoreInterop, SnapshotStoreInterop}
 import cats.effect.Async
 import com.evolutiongaming.catshelper.{FromFuture, LogOf, ToTry}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.persistence.{EventStoreInterop, SnapshotStoreInterop}
 
 import scala.concurrent.duration.*
 

--- a/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/Persistence.scala
+++ b/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/Persistence.scala
@@ -1,6 +1,5 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.actor.ActorRef
 import cats.effect.implicits.effectResourceOps
 import cats.effect.{Ref, Resource, Sync}
 import cats.syntax.all.*
@@ -8,6 +7,7 @@ import com.evolution.pekkoeffect.*
 import com.evolution.pekkoeffect.ActorVar.Directive
 import com.evolution.pekkoeffect.Fail.implicits.*
 import com.evolution.pekkoeffect.Releasable.implicits.*
+import org.apache.pekko.actor.ActorRef
 
 private[pekkoeffect] trait Persistence[F[_], S, E, C] {
 

--- a/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/PersistenceVar.scala
+++ b/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/PersistenceVar.scala
@@ -1,11 +1,11 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.actor.{ActorContext, ActorRef}
 import cats.effect.{Async, Resource, Sync}
 import cats.syntax.all.*
 import com.evolution.pekkoeffect.*
 import com.evolution.pekkoeffect.ActorVar.Directive
 import com.evolutiongaming.catshelper.ToFuture
+import org.apache.pekko.actor.{ActorContext, ActorRef}
 
 private[pekkoeffect] trait PersistenceVar[F[_], S, E, C] {
 

--- a/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/PersistentActorEffect.scala
+++ b/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/PersistentActorEffect.scala
@@ -1,9 +1,9 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.actor.Props
 import cats.effect.{Async, Resource}
 import com.evolution.pekkoeffect.{ActorEffect, ActorRefOf}
 import com.evolutiongaming.catshelper.{FromFuture, ToFuture, ToTry}
+import org.apache.pekko.actor.Props
 
 object PersistentActorEffect {
 

--- a/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/PersistentActorOf.scala
+++ b/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/PersistentActorOf.scala
@@ -1,8 +1,5 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.actor.ReceiveTimeout
-import org.apache.pekko.persistence as ap
-import org.apache.pekko.persistence.{PersistentActor, RecoveryCompleted}
 import cats.effect.implicits.effectResourceOps
 import cats.effect.{Async, Resource, Sync}
 import cats.syntax.all.*
@@ -10,6 +7,9 @@ import com.evolution.pekkoeffect.*
 import com.evolution.pekkoeffect.util.AtomicRef
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.{FromFuture, Memoize, ToFuture, ToTry}
+import org.apache.pekko.actor.ReceiveTimeout
+import org.apache.pekko.persistence as ap
+import org.apache.pekko.persistence.{PersistentActor, RecoveryCompleted}
 
 import scala.collection.immutable.Seq
 import scala.concurrent.duration.*

--- a/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/Snapshotter.scala
+++ b/persistence/src/main/scala/com/evolution/pekkoeffect/persistence/Snapshotter.scala
@@ -1,11 +1,11 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.persistence.{SnapshotSelectionCriteria, Snapshotter as _, *}
 import cats.effect.Sync
 import cats.syntax.all.*
 import cats.{Applicative, FlatMap, ~>}
 import com.evolution.pekkoeffect.Fail
 import com.evolutiongaming.catshelper.{FromFuture, Log, MeasureDuration, MonadThrowable}
+import org.apache.pekko.persistence.{SnapshotSelectionCriteria, Snapshotter as _, *}
 
 import java.time.Instant
 import scala.concurrent.duration.FiniteDuration

--- a/persistence/src/main/scala/org/apache/pekko/persistence/DeleteEventsToInterop.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/DeleteEventsToInterop.scala
@@ -1,12 +1,12 @@
 package org.apache.pekko.persistence
 
-import org.apache.pekko.actor.{ActorContext, ActorRef}
-import org.apache.pekko.persistence.JournalProtocol.DeleteMessagesTo
 import cats.effect.{Resource, Sync}
 import cats.syntax.all.*
 import com.evolution.pekkoeffect.persistence.{DeleteEventsTo, SeqNr}
 import com.evolution.pekkoeffect.{ActorRefOf, AskFrom}
 import com.evolutiongaming.catshelper.FromFuture
+import org.apache.pekko.actor.{ActorContext, ActorRef}
+import org.apache.pekko.persistence.JournalProtocol.DeleteMessagesTo
 
 import scala.concurrent.duration.FiniteDuration
 

--- a/persistence/src/main/scala/org/apache/pekko/persistence/LocalActorRef.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/LocalActorRef.scala
@@ -1,11 +1,11 @@
 package org.apache.pekko.persistence
 
-import org.apache.pekko.actor.{ActorPath, ActorRef, ActorRefProvider, MinimalActorRef}
 import cats.effect.syntax.all.*
 import cats.effect.{Async, Deferred, Sync, Temporal}
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.CatsHelper.OpsCatsHelper
 import com.evolutiongaming.catshelper.{SerialRef, ToTry}
+import org.apache.pekko.actor.{ActorPath, ActorRef, ActorRefProvider, MinimalActorRef}
 
 import java.util.concurrent.TimeoutException
 import scala.concurrent.duration.*

--- a/persistence/src/main/scala/org/apache/pekko/persistence/SnapshotStoreInterop.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/SnapshotStoreInterop.scala
@@ -1,6 +1,5 @@
 package org.apache.pekko.persistence
 
-import org.apache.pekko.persistence.SnapshotSelectionCriteria
 import cats.effect.Sync
 import cats.syntax.all.*
 import com.evolution.pekkoeffect.ActorEffect

--- a/persistence/src/main/scala/org/apache/pekko/persistence/SnapshotterInterop.scala
+++ b/persistence/src/main/scala/org/apache/pekko/persistence/SnapshotterInterop.scala
@@ -1,12 +1,12 @@
 package org.apache.pekko.persistence
 
-import org.apache.pekko.persistence.SnapshotProtocol.{DeleteSnapshot, DeleteSnapshots, Request, SaveSnapshot}
-import org.apache.pekko.util.Timeout
 import cats.effect.Sync
 import cats.syntax.all.*
 import com.evolution.pekkoeffect
 import com.evolution.pekkoeffect.persistence.SeqNr
 import com.evolutiongaming.catshelper.FromFuture
+import org.apache.pekko.persistence.SnapshotProtocol.{DeleteSnapshot, DeleteSnapshots, Request, SaveSnapshot}
+import org.apache.pekko.util.Timeout
 
 import java.time.Instant
 import scala.concurrent.duration.FiniteDuration

--- a/persistence/src/test/scala/com/evolution/pekkoeffect/persistence/AppendTest.scala
+++ b/persistence/src/test/scala/com/evolution/pekkoeffect/persistence/AppendTest.scala
@@ -26,8 +26,6 @@ class AppendTest extends AsyncFunSuite with Matchers {
 
   private def adapter[F[_]: Async: ToFuture: ToTry](act: Act[F]): F[Unit] = {
 
-    case class Event(fa: F[Unit])
-
     def eventsourced(act: Act[F], ref: Ref[F, Queue[F[Unit]]]): F[Append.Eventsourced] =
       Ref[F]
         .of(SeqNr.Min)

--- a/persistence/src/test/scala/com/evolution/pekkoeffect/persistence/EventSourcedActorOfTest.scala
+++ b/persistence/src/test/scala/com/evolution/pekkoeffect/persistence/EventSourcedActorOfTest.scala
@@ -1,19 +1,19 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.actor.{ActorIdentity, ActorRef, ActorSystem, Identify}
-import org.apache.pekko.persistence.Recovery
-import org.apache.pekko.testkit.TestActors
 import cats.data.NonEmptyList as Nel
 import cats.effect.*
 import cats.effect.syntax.all.*
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
+import com.evolution.pekkoeffect.*
 import com.evolution.pekkoeffect.IOSuite.*
 import com.evolution.pekkoeffect.persistence.InstrumentEventSourced.Action
 import com.evolution.pekkoeffect.testkit.Probe
-import com.evolution.pekkoeffect.*
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.{FromFuture, LogOf, ToFuture, ToTry}
+import org.apache.pekko.actor.{ActorIdentity, ActorRef, ActorSystem, Identify}
+import org.apache.pekko.persistence.Recovery
+import org.apache.pekko.testkit.TestActors
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -86,8 +86,8 @@ class EventSourcedActorOfTest extends AsyncFunSuite with ActorSuite with Matcher
     sealed trait Cmd
 
     object Cmd {
-      final case object Inc                               extends Cmd
-      final case object Stop                              extends Cmd
+      case object Inc                                     extends Cmd
+      case object Stop                                    extends Cmd
       final case class WithCtx[A](f: ActorCtx[F] => F[A]) extends Cmd
     }
 
@@ -202,7 +202,7 @@ class EventSourcedActorOfTest extends AsyncFunSuite with ActorSuite with Matcher
       } yield {}
     }
 
-    implicit val log = LogOf.empty[F]
+    implicit val log: LogOf[F] = LogOf.empty[F]
 
     for {
       receiveTimeout <- Deferred[F, Unit]

--- a/persistence/src/test/scala/com/evolution/pekkoeffect/persistence/InstrumentEventSourced.scala
+++ b/persistence/src/test/scala/com/evolution/pekkoeffect/persistence/InstrumentEventSourced.scala
@@ -1,10 +1,10 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.actor.ActorRef
-import org.apache.pekko.persistence.{Recovery, SnapshotSelectionCriteria}
 import cats.effect.{Ref, Resource, Sync}
 import cats.syntax.all.*
 import com.evolution.pekkoeffect.*
+import org.apache.pekko.actor.ActorRef
+import org.apache.pekko.persistence.{Recovery, SnapshotSelectionCriteria}
 
 import java.time.Instant
 
@@ -145,56 +145,56 @@ object InstrumentEventSourced {
       pluginIds: PluginIds,
     ) extends Action[Nothing, Nothing, Nothing]
 
-    final case object Started extends Action[Nothing, Nothing, Nothing]
+    case object Started extends Action[Nothing, Nothing, Nothing]
 
-    final case object Released extends Action[Nothing, Nothing, Nothing]
+    case object Released extends Action[Nothing, Nothing, Nothing]
 
     final case class RecoveryAllocated[S](
       seqNr: SeqNr,
       snapshotOffer: Option[SnapshotOffer[S]],
     ) extends Action[S, Nothing, Nothing]
 
-    final case object RecoveryReleased extends Action[Nothing, Nothing, Nothing]
+    case object RecoveryReleased extends Action[Nothing, Nothing, Nothing]
 
-    final case object ReplayAllocated extends Action[Nothing, Nothing, Nothing]
+    case object ReplayAllocated extends Action[Nothing, Nothing, Nothing]
 
-    final case object ReplayReleased extends Action[Nothing, Nothing, Nothing]
+    case object ReplayReleased extends Action[Nothing, Nothing, Nothing]
 
     final case class Replayed[S, E](event: E, seqNr: SeqNr) extends Action[S, Nothing, E]
 
     final case class AppendEvents[E](events: Events[E]) extends Action[Nothing, Nothing, E]
 
-    final case object AppendEventsOuter extends Action[Nothing, Nothing, Nothing]
+    case object AppendEventsOuter extends Action[Nothing, Nothing, Nothing]
 
     final case class AppendEventsInner(seqNr: SeqNr) extends Action[Nothing, Nothing, Nothing]
 
     final case class DeleteEventsTo(seqNr: SeqNr) extends Action[Nothing, Nothing, Nothing]
 
-    final case object DeleteEventsToOuter extends Action[Nothing, Nothing, Nothing]
+    case object DeleteEventsToOuter extends Action[Nothing, Nothing, Nothing]
 
-    final case object DeleteEventsToInner extends Action[Nothing, Nothing, Nothing]
+    case object DeleteEventsToInner extends Action[Nothing, Nothing, Nothing]
 
     final case class SaveSnapshot[S](seqNr: SeqNr, snapshot: S) extends Action[S, Nothing, Nothing]
 
-    final case object SaveSnapshotOuter extends Action[Nothing, Nothing, Nothing]
+    case object SaveSnapshotOuter extends Action[Nothing, Nothing, Nothing]
 
-    final case object SaveSnapshotInner extends Action[Nothing, Nothing, Nothing]
+    case object SaveSnapshotInner extends Action[Nothing, Nothing, Nothing]
 
     final case class DeleteSnapshot(seqNr: SeqNr) extends Action[Nothing, Nothing, Nothing]
 
-    final case object DeleteSnapshotOuter extends Action[Nothing, Nothing, Nothing]
+    case object DeleteSnapshotOuter extends Action[Nothing, Nothing, Nothing]
 
-    final case object DeleteSnapshotInner extends Action[Nothing, Nothing, Nothing]
+    case object DeleteSnapshotInner extends Action[Nothing, Nothing, Nothing]
 
     final case class DeleteSnapshots(criteria: SnapshotSelectionCriteria) extends Action[Nothing, Nothing, Nothing]
 
-    final case object DeleteSnapshotsOuter extends Action[Nothing, Nothing, Nothing]
+    case object DeleteSnapshotsOuter extends Action[Nothing, Nothing, Nothing]
 
-    final case object DeleteSnapshotsInner extends Action[Nothing, Nothing, Nothing]
+    case object DeleteSnapshotsInner extends Action[Nothing, Nothing, Nothing]
 
     final case class ReceiveAllocated[S](seqNr: SeqNr) extends Action[S, Nothing, Nothing]
 
-    final case object ReceiveReleased extends Action[Nothing, Nothing, Nothing]
+    case object ReceiveReleased extends Action[Nothing, Nothing, Nothing]
 
     final case class Received[C](
       cmd: C,
@@ -202,6 +202,6 @@ object InstrumentEventSourced {
       stop: Boolean,
     ) extends Action[Nothing, C, Nothing]
 
-    final case object ReceiveTimeout extends Action[Nothing, Nothing, Nothing]
+    case object ReceiveTimeout extends Action[Nothing, Nothing, Nothing]
   }
 }

--- a/persistence/src/test/scala/com/evolution/pekkoeffect/persistence/PersistenceFailureTest.scala
+++ b/persistence/src/test/scala/com/evolution/pekkoeffect/persistence/PersistenceFailureTest.scala
@@ -1,14 +1,14 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.actor.Props
-import org.apache.pekko.persistence.journal.AsyncWriteJournal
-import org.apache.pekko.persistence.{AtomicWrite, PersistentRepr}
 import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, Resource}
 import cats.syntax.all.*
 import com.evolution.pekkoeffect.testkit.TestActorSystem
 import com.evolution.pekkoeffect.{Envelope, Receive}
 import com.evolutiongaming.catshelper.LogOf
+import org.apache.pekko.actor.Props
+import org.apache.pekko.persistence.journal.AsyncWriteJournal
+import org.apache.pekko.persistence.{AtomicWrite, PersistentRepr}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -55,9 +55,9 @@ class PersistenceFailureTest extends AnyFunSuite with Matchers {
 
   test("EventSourcedActorOf based actor must fail if journal fails to persist message") {
 
-    implicit val log = LogOf.empty[IO]
+    implicit val log: LogOf[IO] = LogOf.empty[IO]
 
-    TestActorSystem[IO]("testing", none)
+    TestActorSystem[IO]("testing", None)
       .use { system =>
         val persistence = EventSourcedPersistence.fromPekkoPlugins[IO](system, 1.second, 100)
         def actor       = EventSourcedActorOf.actor[IO, Any, Any](eventSourced, persistence)
@@ -84,7 +84,7 @@ class PersistenceFailureTest extends AnyFunSuite with Matchers {
 
   test("PersistentActorOf based actor must fail if journal fails to persist message") {
 
-    TestActorSystem[IO]("testing", none)
+    TestActorSystem[IO]("testing", None)
       .use { system =>
         def actor = PersistentActorOf[IO](eventSourced)
         val ref   = system.actorOf(Props(actor))

--- a/persistence/src/test/scala/com/evolution/pekkoeffect/persistence/PersistentActorOfTest.scala
+++ b/persistence/src/test/scala/com/evolution/pekkoeffect/persistence/PersistentActorOfTest.scala
@@ -1,20 +1,20 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.actor.{ActorIdentity, ActorRef, ActorSystem, Identify}
-import org.apache.pekko.persistence.Recovery
-import org.apache.pekko.testkit.TestActors
 import cats.data.NonEmptyList as Nel
 import cats.effect.*
 import cats.effect.kernel.Ref
 import cats.effect.syntax.all.*
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
+import com.evolution.pekkoeffect.*
 import com.evolution.pekkoeffect.IOSuite.*
 import com.evolution.pekkoeffect.persistence.InstrumentEventSourced.Action
 import com.evolution.pekkoeffect.testkit.Probe
-import com.evolution.pekkoeffect.*
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.{FromFuture, ToFuture, ToTry}
+import org.apache.pekko.actor.{ActorIdentity, ActorRef, ActorSystem, Identify}
+import org.apache.pekko.persistence.Recovery
+import org.apache.pekko.testkit.TestActors
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -82,8 +82,8 @@ class PersistentActorOfTest extends AsyncFunSuite with ActorSuite with Matchers 
     sealed trait Cmd
 
     object Cmd {
-      final case object Inc                               extends Cmd
-      final case object Stop                              extends Cmd
+      case object Inc                                     extends Cmd
+      case object Stop                                    extends Cmd
       final case class WithCtx[A](f: ActorCtx[F] => F[A]) extends Cmd
     }
 

--- a/persistence/src/test/scala/com/evolution/pekkoeffect/persistence/SnapshotterTest.scala
+++ b/persistence/src/test/scala/com/evolution/pekkoeffect/persistence/SnapshotterTest.scala
@@ -1,16 +1,16 @@
 package com.evolution.pekkoeffect.persistence
 
-import org.apache.pekko.actor.{ActorRef, ActorSystem, Props}
-import org.apache.pekko.persistence.{SnapshotMetadata as _, Snapshotter as _, *}
 import cats.effect.implicits.effectResourceOps
 import cats.effect.unsafe.implicits.global
 import cats.effect.{Async, Deferred, IO, Sync}
 import cats.syntax.all.*
+import com.evolution.pekkoeffect.*
 import com.evolution.pekkoeffect.IOSuite.*
 import com.evolution.pekkoeffect.testkit.Probe
-import com.evolution.pekkoeffect.*
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.{FromFuture, ToFuture}
+import org.apache.pekko.actor.{ActorRef, ActorSystem, Props}
+import org.apache.pekko.persistence.{SnapshotMetadata as _, Snapshotter as _, *}
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 

--- a/persistence/src/test/scala/org/apache/pekko/persistence/DeleteEventsToInteropTest.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/DeleteEventsToInteropTest.scala
@@ -1,7 +1,5 @@
 package org.apache.pekko.persistence
 
-import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, Props}
-import org.apache.pekko.persistence.JournalProtocol.DeleteMessagesTo
 import cats.effect.implicits.effectResourceOps
 import cats.effect.unsafe.implicits.global
 import cats.effect.{Async, Deferred, IO, Sync}
@@ -12,6 +10,8 @@ import com.evolution.pekkoeffect.persistence.DeleteEventsTo
 import com.evolution.pekkoeffect.testkit.Probe
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.{FromFuture, ToFuture}
+import org.apache.pekko.actor.{Actor, ActorRef, ActorSystem, Props}
+import org.apache.pekko.persistence.JournalProtocol.DeleteMessagesTo
 import org.scalatest.funsuite.AsyncFunSuite
 import org.scalatest.matchers.should.Matchers
 

--- a/persistence/src/test/scala/org/apache/pekko/persistence/SnapshotStoreInteropTest.scala
+++ b/persistence/src/test/scala/org/apache/pekko/persistence/SnapshotStoreInteropTest.scala
@@ -1,12 +1,12 @@
 package org.apache.pekko.persistence
 
-import org.apache.pekko.pattern.AskTimeoutException
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import cats.syntax.all.*
 import com.evolution.pekkoeffect.persistence.{EventSourcedId, SeqNr, SnapshotStore}
 import com.evolution.pekkoeffect.testkit.TestActorSystem
 import com.evolutiongaming.catshelper.LogOf
+import org.apache.pekko.pattern.AskTimeoutException
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -26,7 +26,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val persistenceId = EventSourcedId("#1")
     val payload       = Random.nextString(1024)
 
-    val io = TestActorSystem[IO]("testing", none)
+    val io = TestActorSystem[IO]("testing", None)
       .use { system =>
         for {
           store    <- SnapshotStoreInterop[IO](Persistence(system), 1.second, emptyPluginId, persistenceId)
@@ -46,7 +46,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val persistenceId = EventSourcedId("#2")
     val payload       = Random.nextString(1024)
 
-    val io = TestActorSystem[IO]("testing", none)
+    val io = TestActorSystem[IO]("testing", None)
       .use { system =>
         for {
           store    <- SnapshotStoreInterop[IO](Persistence(system), 1.second, emptyPluginId, persistenceId)
@@ -67,7 +67,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val pluginId      = "failing-snapshot"
     val persistenceId = EventSourcedId("#3")
 
-    val io = TestActorSystem[IO]("testing", none)
+    val io = TestActorSystem[IO]("testing", None)
       .use { system =>
         for {
           store <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)
@@ -85,7 +85,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val persistenceId = EventSourcedId("#4")
     val payload       = Random.nextString(1024)
 
-    val io = TestActorSystem[IO]("testing", none)
+    val io = TestActorSystem[IO]("testing", None)
       .use { system =>
         for {
           store  <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)
@@ -103,7 +103,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val pluginId      = "failing-snapshot"
     val persistenceId = EventSourcedId("#5")
 
-    val io = TestActorSystem[IO]("testing", none)
+    val io = TestActorSystem[IO]("testing", None)
       .use { system =>
         for {
           store    <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)
@@ -121,7 +121,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val pluginId      = "failing-snapshot"
     val persistenceId = EventSourcedId("#6")
 
-    val io = TestActorSystem[IO]("testing", none)
+    val io = TestActorSystem[IO]("testing", None)
       .use { system =>
         for {
           store    <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)
@@ -139,7 +139,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val pluginId      = "infinite-snapshot"
     val persistenceId = EventSourcedId("#7")
 
-    val io = TestActorSystem[IO]("testing", none)
+    val io = TestActorSystem[IO]("testing", None)
       .use(system =>
         for {
           store <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)
@@ -160,7 +160,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val persistenceId = EventSourcedId("#8")
     val payload       = Random.nextString(1024)
 
-    val io = TestActorSystem[IO]("testing", none)
+    val io = TestActorSystem[IO]("testing", None)
       .use { system =>
         for {
           store  <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)
@@ -181,7 +181,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val pluginId      = "infinite-snapshot"
     val persistenceId = EventSourcedId("#9")
 
-    val io = TestActorSystem[IO]("testing", none)
+    val io = TestActorSystem[IO]("testing", None)
       .use { system =>
         for {
           store    <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)
@@ -202,7 +202,7 @@ class SnapshotStoreInteropTest extends AnyFunSuite with Matchers {
     val pluginId      = "infinite-snapshot"
     val persistenceId = EventSourcedId("#10")
 
-    val io = TestActorSystem[IO]("testing", none)
+    val io = TestActorSystem[IO]("testing", None)
       .use { system =>
         for {
           store    <- SnapshotStoreInterop[IO](Persistence(system), 1.second, pluginId, persistenceId)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,14 +2,16 @@ import sbt._
 
 object Dependencies {
 
-  val scalatest                   = "org.scalatest"         %% "scalatest"                 % "3.2.19"
-  val `cats-helper`               = "com.evolutiongaming"   %% "cats-helper"               % "3.12.0"
-  val retry                       = "com.evolutiongaming"   %% "retry"                     % "3.1.0"
-  val `pekko-persistence-inmemory` = "io.github.alstanchev" %% "pekko-persistence-inmemory" % "1.3.0"
-  val `kind-projector`            = "org.typelevel"          % "kind-projector"            % "0.13.3"
-  val pureconfig                  = "com.github.pureconfig" %% "pureconfig"                % "0.17.8"
-  val smetrics                    = "com.evolutiongaming"   %% "smetrics"                  % "2.3.1"
-  val sstream                     = "com.evolutiongaming"   %% "sstream"                   % "1.1.0"
+  val scalatest                    = "org.scalatest"         %% "scalatest"                  % "3.2.19"
+  val `cats-helper`                = "com.evolutiongaming"   %% "cats-helper"                % "3.12.0"
+  val retry                        = "com.evolutiongaming"   %% "retry"                      % "3.1.0"
+  val `pekko-persistence-inmemory` = "io.github.alstanchev"  %% "pekko-persistence-inmemory" % "1.3.0"
+  val `kind-projector`             = "org.typelevel"          % "kind-projector"             % "0.13.3"
+  val pureconfig                   = "com.github.pureconfig" %% "pureconfig"                 % "0.17.8"
+  val `pureconfig-scala3`          = "com.github.pureconfig" %% "pureconfig-core"            % "0.17.8"
+  val `pureconfig-generic-scala3`  = "com.github.pureconfig" %% "pureconfig-generic-scala3"  % "0.17.8"
+  val smetrics                     = "com.evolutiongaming"   %% "smetrics"                   % "2.3.1"
+  val sstream                      = "com.evolutiongaming"   %% "sstream"                    % "1.1.0"
 
   object Cats {
     private val version = "2.13.0"
@@ -22,7 +24,7 @@ object Dependencies {
   }
 
   object Pekko {
-    private val version = "1.1.3"
+    private val version     = "1.1.3"
     val actor               = "org.apache.pekko" %% "pekko-actor"             % version
     val testkit             = "org.apache.pekko" %% "pekko-testkit"           % version
     val stream              = "org.apache.pekko" %% "pekko-stream"            % version

--- a/testkit/src/main/scala/com/evolution/pekkoeffect/testkit/Probe.scala
+++ b/testkit/src/main/scala/com/evolution/pekkoeffect/testkit/Probe.scala
@@ -1,6 +1,5 @@
 package com.evolution.pekkoeffect.testkit
 
-import org.apache.pekko.actor.{ActorRef, Props}
 import cats.effect.implicits.effectResourceOps
 import cats.effect.kernel.Deferred
 import cats.effect.{Async, Ref, Resource, Sync}
@@ -8,6 +7,7 @@ import cats.syntax.all.*
 import com.evolution.pekkoeffect.*
 import com.evolutiongaming.catshelper.CatsHelper.*
 import com.evolutiongaming.catshelper.{FromFuture, ToFuture}
+import org.apache.pekko.actor.{ActorRef, Props}
 
 import scala.concurrent.duration.*
 import scala.reflect.ClassTag
@@ -28,10 +28,6 @@ object Probe {
   def of[F[_]: Async: ToFuture: FromFuture](
     actorRefOf: ActorRefOf[F],
   ): Resource[F, Probe[F]] = {
-
-    final case class Watch(actorRef: ActorRef)
-
-    final case class Terminated(actorRef: ActorRef)
 
     type Unsubscribe = Boolean
 
@@ -125,4 +121,8 @@ object Probe {
       }
     }
   }
+
+  final private case class Watch(actorRef: ActorRef)
+
+  final private case class Terminated(actorRef: ActorRef)
 }

--- a/testkit/src/main/scala/com/evolution/pekkoeffect/testkit/TestActorSystem.scala
+++ b/testkit/src/main/scala/com/evolution/pekkoeffect/testkit/TestActorSystem.scala
@@ -1,11 +1,11 @@
 package com.evolution.pekkoeffect.testkit
 
-import org.apache.pekko.actor.ActorSystem
 import cats.effect.implicits.effectResourceOps
 import cats.effect.{Async, Resource, Sync}
 import cats.syntax.all.*
 import com.evolutiongaming.catshelper.FromFuture
 import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.pekko.actor.ActorSystem
 
 import scala.concurrent.ExecutionContext
 


### PR DESCRIPTION
for Scala 3 support I had to:
* move out some case classes from their in-`def` definitions
* remove `final` from `case object` definitions
* add some types in definitions
* add magic for `pureconfig` integartion