### PR TITLE
drop `pekko-persistence-inmemory` in faviour of pekko's internal version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -147,6 +147,7 @@ lazy val persistence = project
       Pekko.actor,
       Pekko.stream,
       Pekko.persistence,
+      Pekko.`persistence-testkit` % Test,
       Pekko.`persistence-query`,
       Pekko.slf4j   % Test,
       Pekko.testkit % Test,
@@ -154,8 +155,7 @@ lazy val persistence = project
       CatsEffect.effect,
       `cats-helper`,
       smetrics,
-      scalatest                    % Test,
-      `pekko-persistence-inmemory` % Test,
+      scalatest % Test,
     ),
     libraryDependencies ++= crossSettings(
       scalaVersion = scalaVersion.value,
@@ -189,6 +189,7 @@ lazy val cluster = project
   .settings(
     libraryDependencies ++= Seq(
       Pekko.cluster,
+      Pekko.`cluster-typed` % Test,
     ),
     libraryDependencies ++= crossSettings(
       scalaVersion = scalaVersion.value,

--- a/persistence/src/test/resources/test.conf
+++ b/persistence/src/test/resources/test.conf
@@ -4,9 +4,15 @@ pekko {
   loggers = ["org.apache.pekko.event.slf4j.Slf4jLogger"]
   logging-filter = "org.apache.pekko.event.slf4j.Slf4jLoggingFilter"
   persistence {
-    journal.plugin = "inmemory-journal"
-    snapshot-store.plugin = "inmemory-snapshot-store"
+    journal.plugin = "pekko.persistence.journal.inmem"
+    snapshot-store.plugin = "pekko.persistence.snapshot-store.inmem"
   }
+}
+
+# In-memory snapshot-store plugin.
+pekko.persistence.snapshot-store.inmem {
+  # Class name of the plugin.
+  class = "org.apache.pekko.persistence.testkit.PersistenceTestKitSnapshotPlugin"
 }
 
 fail-on-event-journal {

--- a/persistence/src/test/scala/com/evolution/pekkoeffect/persistence/PersistenceFailureTest.scala
+++ b/persistence/src/test/scala/com/evolution/pekkoeffect/persistence/PersistenceFailureTest.scala
@@ -26,7 +26,7 @@ class PersistenceFailureTest extends AnyFunSuite with Matchers {
     IO {
 
       val journal  = "fail-on-event-journal"
-      val snapshot = "inmemory-snapshot-store"
+      val snapshot = "pekko.persistence.snapshot-store.inmem"
 
       EventSourced(
         eventSourcedId = EventSourcedId("test"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,15 +2,15 @@ import sbt._
 
 object Dependencies {
 
-  val scalatest                    = "org.scalatest"         %% "scalatest"                  % "3.2.19"
-  val `cats-helper`                = "com.evolutiongaming"   %% "cats-helper"                % "3.12.0"
-  val retry                        = "com.evolutiongaming"   %% "retry"                      % "3.1.0"
-  val `kind-projector`             = "org.typelevel"          % "kind-projector"             % "0.13.3"
-  val pureconfig                   = "com.github.pureconfig" %% "pureconfig"                 % "0.17.8"
-  val `pureconfig-scala3`          = "com.github.pureconfig" %% "pureconfig-core"            % "0.17.8"
-  val `pureconfig-generic-scala3`  = "com.github.pureconfig" %% "pureconfig-generic-scala3"  % "0.17.8"
-  val smetrics                     = "com.evolutiongaming"   %% "smetrics"                   % "2.3.1"
-  val sstream                      = "com.evolutiongaming"   %% "sstream"                    % "1.1.0"
+  val scalatest                   = "org.scalatest"         %% "scalatest"                 % "3.2.19"
+  val `cats-helper`               = "com.evolutiongaming"   %% "cats-helper"               % "3.12.0"
+  val retry                       = "com.evolutiongaming"   %% "retry"                     % "3.1.0"
+  val `kind-projector`            = "org.typelevel"          % "kind-projector"            % "0.13.3"
+  val pureconfig                  = "com.github.pureconfig" %% "pureconfig"                % "0.17.8"
+  val `pureconfig-scala3`         = "com.github.pureconfig" %% "pureconfig-core"           % "0.17.8"
+  val `pureconfig-generic-scala3` = "com.github.pureconfig" %% "pureconfig-generic-scala3" % "0.17.8"
+  val smetrics                    = "com.evolutiongaming"   %% "smetrics"                  % "2.3.1"
+  val sstream                     = "com.evolutiongaming"   %% "sstream"                   % "1.1.0"
 
   object Cats {
     private val version = "2.13.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,6 @@ object Dependencies {
   val scalatest                    = "org.scalatest"         %% "scalatest"                  % "3.2.19"
   val `cats-helper`                = "com.evolutiongaming"   %% "cats-helper"                % "3.12.0"
   val retry                        = "com.evolutiongaming"   %% "retry"                      % "3.1.0"
-  val `pekko-persistence-inmemory` = "io.github.alstanchev"  %% "pekko-persistence-inmemory" % "1.3.0"
   val `kind-projector`             = "org.typelevel"          % "kind-projector"             % "0.13.3"
   val pureconfig                   = "com.github.pureconfig" %% "pureconfig"                 % "0.17.8"
   val `pureconfig-scala3`          = "com.github.pureconfig" %% "pureconfig-core"            % "0.17.8"
@@ -24,15 +23,17 @@ object Dependencies {
   }
 
   object Pekko {
-    private val version     = "1.1.3"
-    val actor               = "org.apache.pekko" %% "pekko-actor"             % version
-    val testkit             = "org.apache.pekko" %% "pekko-testkit"           % version
-    val stream              = "org.apache.pekko" %% "pekko-stream"            % version
-    val persistence         = "org.apache.pekko" %% "pekko-persistence"       % version
-    val `persistence-query` = "org.apache.pekko" %% "pekko-persistence-query" % version
-    val cluster             = "org.apache.pekko" %% "pekko-cluster"           % version
-    val `cluster-sharding`  = "org.apache.pekko" %% "pekko-cluster-sharding"  % version
-    val slf4j               = "org.apache.pekko" %% "pekko-slf4j"             % version
+    private val version       = "1.1.3"
+    val actor                 = "org.apache.pekko" %% "pekko-actor"               % version
+    val testkit               = "org.apache.pekko" %% "pekko-testkit"             % version
+    val stream                = "org.apache.pekko" %% "pekko-stream"              % version
+    val persistence           = "org.apache.pekko" %% "pekko-persistence"         % version
+    val `persistence-testkit` = "org.apache.pekko" %% "pekko-persistence-testkit" % version
+    val `persistence-query`   = "org.apache.pekko" %% "pekko-persistence-query"   % version
+    val cluster               = "org.apache.pekko" %% "pekko-cluster"             % version
+    val `cluster-typed`       = "org.apache.pekko" %% "pekko-cluster-typed"       % version
+    val `cluster-sharding`    = "org.apache.pekko" %% "pekko-cluster-sharding"    % version
+    val slf4j                 = "org.apache.pekko" %% "pekko-slf4j"               % version
   }
 
   object Logback {


### PR DESCRIPTION
There is an exposed `inmem` Journal implementation in Pekko and there is mostly hidden `inmem` Snapshot Store implementation too.

Sadly, the `snapshot-store` version is not exposed as nicely.

During [discussion](https://github.com/apache/pekko/discussions/1856) I found the way, which just might work.